### PR TITLE
Fix: first lunch "integer expression expected" error

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -334,7 +334,7 @@ function set_ccache()
     fi
 
     if [ -z "$CCACHE_SIZE" ]; then
-        if [ "$1" -eq "mokee_default" ]; then
+        if [ "$1" = "mokee_default" ]; then
             CCACHE_SIZE=50G
         else
             CCACHE_SIZE=16G


### PR DESCRIPTION
eg:
first execute `lunch mk_oneplus3-userdebug`

output
-bash: [: mk_oneplus3: integer expression expected